### PR TITLE
Overwrite existing Vault binary

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -17,7 +17,7 @@ curl -Ls -o kubectl "https://storage.googleapis.com/kubernetes-release/release/v
 
 # Install Vault client
 curl -Ls -O "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" \
-&& unzip vault_${VAULT_VERSION}_linux_amd64.zip \
+&& unzip -o vault_${VAULT_VERSION}_linux_amd64.zip \
 && chmod +x vault \
 && sudo mv vault /usr/local/bin \
 && rm vault_${VAULT_VERSION}_linux_amd64.zip


### PR DESCRIPTION
This should fix the following error message:
```
...
2021-10-13T11:19:50.8225123Z replace vault? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
2021-10-13T11:19:50.8228807Z (EOF or read error, treating as "[N]one" ...)
2021-10-13T11:19:50.8231880Z Archive:  vault_1.1.3_linux_amd64.zip
...
```

I do not know what causes this error message, but it might be the reason why the following CI/CD pipeline fails:
* https://github.com/kfzteile24/payment-advice-service/runs/3881775290?check_suite_focus=true